### PR TITLE
Load more when reached bottom of window container on windowscroll

### DIFF
--- a/dist/ReactProgressiveList.js
+++ b/dist/ReactProgressiveList.js
@@ -188,7 +188,7 @@ var _initialiseProps = function _initialiseProps() {
       top = boundingClientRect.top;
       height = boundingClientRect.height;
       scrollHeight = window.innerHeight;
-      reachedLimit = top + height < scrollHeight;
+      reachedLimit = top + height <= scrollHeight;
     } else {
       top = e.target.scrollTop;
       height = e.target.offsetHeight;

--- a/src/ReactProgressiveList.js
+++ b/src/ReactProgressiveList.js
@@ -74,7 +74,7 @@ class ReactProgressiveList extends React.PureComponent<Props, State> {
       top = boundingClientRect.top;
       height = boundingClientRect.height;
       scrollHeight = window.innerHeight;
-      reachedLimit = top + height < scrollHeight;
+      reachedLimit = top + height <= scrollHeight;
     } else {
       top = e.target.scrollTop;
       height = e.target.offsetHeight;


### PR DESCRIPTION
Unless checking for equal height when using windowScroll, the reachedLimit variable never gets set to true